### PR TITLE
Prevent preview overlapping with viewport information

### DIFF
--- a/addons/anthonyec.camera_preview/drag_handle.gd
+++ b/addons/anthonyec.camera_preview/drag_handle.gd
@@ -1,6 +1,0 @@
-extends Button
-
-func _get_drag_data(at_position: Vector2) -> Variant:
-	var duplicate = get_parent().duplicate()
-	set_drag_preview(duplicate)
-	return {}


### PR DESCRIPTION
When showing viewport information, the camera preview would overlap it. Instead offset the camera preview margins if the information is shown.

Note this only works with one viewport, not with multiple in split view.

![example_compared](https://github.com/anthonyec/godot_little_camera_preview/assets/1451668/00684157-e2ba-4e32-acbf-80059a2ea4c2)

Alleviates (not a complete fix): https://github.com/anthonyec/godot_little_camera_preview/issues/5