### PR TITLE
Fix portrait aspect ratio being stretched

### DIFF
--- a/addons/anthonyec.camera_preview/preview.gd
+++ b/addons/anthonyec.camera_preview/preview.gd
@@ -356,7 +356,8 @@ func get_clamped_size(desired_size: Vector2) -> Vector2:
 		clamped_size.y = min_panel_size * viewport_ratio
 		clamped_size = clamped_size * editor_scale
 	
-	return clamped_size
+	# Round down to avoid sub-pixel artifacts, mainly seen around the margins.
+	return clamped_size.floor()
 	
 func get_project_window_size() -> Vector2:
 	var window_width = float(ProjectSettings.get_setting("display/window/size/viewport_width"))

--- a/addons/anthonyec.camera_preview/preview.gd
+++ b/addons/anthonyec.camera_preview/preview.gd
@@ -341,11 +341,11 @@ func get_clamped_size(desired_size: Vector2) -> Vector2:
 		clamped_size.x = max_bounds.x
 		clamped_size.y = max_bounds.x * viewport_ratio
 	
-	# Clamp the min size based on if it's portrait or landscape.
+	# Clamp the min size based on if it's portrait or landscape. Portrait min
+	# size should be based on it's height. Landscape min size is based on it's
+	# width instead. Applying min width to a portrait size would make it too big.
 	var is_portrait = viewport_ratio > 1
 	
-	# Min panel size needs to be scaled by the display scale (e.g retina) since
-	# it's a hard-coded pixel value.
 	if is_portrait and clamped_size.y <= min_panel_size * editor_scale:
 		clamped_size.x = min_panel_size / viewport_ratio
 		clamped_size.y = min_panel_size

--- a/addons/anthonyec.camera_preview/preview.gd
+++ b/addons/anthonyec.camera_preview/preview.gd
@@ -268,19 +268,12 @@ func get_clamped_size(desired_size: Vector2) -> Vector2:
 	var viewport_ratio = get_project_window_ratio()
 	var editor_viewport_size = get_editor_viewport_size()
 
-	var min_bounds = Vector2(
-		editor_viewport_size.x * 0.1,
-		editor_viewport_size.x * 0.1 * viewport_ratio
-	)
-	
 	var max_bounds = Vector2(
 		editor_viewport_size.x * 0.6,
 		editor_viewport_size.y * 0.8
 	)
 	
-	# Apply an initial clamp for the min size. The max bounds gets clamped 
-	# again later respect aspect ratio.
-	var clamped_size = desired_size.clamp(min_bounds, max_bounds)
+	var clamped_size = desired_size
 	
 	# Apply aspect ratio.
 	clamped_size = Vector2(clamped_size.x, clamped_size.x * viewport_ratio)
@@ -293,6 +286,21 @@ func get_clamped_size(desired_size: Vector2) -> Vector2:
 	if clamped_size.x >= max_bounds.x:
 		clamped_size.x = max_bounds.x
 		clamped_size.y = max_bounds.x * viewport_ratio
+	
+	# Clamp the min size based on if it's portrait or landscape.
+	var is_portrait = viewport_ratio > 1
+	
+	# Min panel size needs to be scaled by the display scale (e.g retina) since
+	# it's a hard-coded pixel value.
+	if is_portrait and clamped_size.y <= min_panel_size * screen_scale:
+		clamped_size.x = min_panel_size / viewport_ratio
+		clamped_size.y = min_panel_size
+		clamped_size = clamped_size * screen_scale
+		
+	if not is_portrait and clamped_size.x <= min_panel_size * screen_scale:
+		clamped_size.x = min_panel_size
+		clamped_size.y = min_panel_size * viewport_ratio
+		clamped_size = clamped_size * screen_scale
 	
 	return clamped_size
 	

--- a/addons/anthonyec.camera_preview/preview.gd
+++ b/addons/anthonyec.camera_preview/preview.gd
@@ -76,15 +76,7 @@ func _process(_delta: float) -> void:
 	
 	match state:
 		InteractionState.NONE:
-			# Constrain panel size to aspect ratio.
-			panel.size.y = panel.size.x * viewport_ratio
-			
-			# Clamp size.
-			panel.size = panel.size.clamp(
-				Vector2(min_panel_width * screen_scale, min_panel_width * screen_scale * viewport_ratio),
-				Vector2(size.x * max_panel_width_ratio, size.x * max_panel_width_ratio * viewport_ratio)
-			)
-			
+			panel.size = get_clamped_size(viewport_ratio)
 			panel.position = get_pinned_position(pinned_position)
 			
 		InteractionState.RESIZE:
@@ -95,16 +87,8 @@ func _process(_delta: float) -> void:
 				
 			if pinned_position == PinnedPosition.RIGHT:
 				panel.size = initial_panel_size + delta_mouse_position
-				
-			# Constrain panel size to aspect ratio.
-			panel.size.y = panel.size.x * viewport_ratio
 			
-			# Clamp size.
-			panel.size = panel.size.clamp(
-				Vector2(min_panel_width * screen_scale, min_panel_width * screen_scale * viewport_ratio),
-				Vector2(size.x * max_panel_width_ratio, size.x * max_panel_width_ratio * viewport_ratio)
-			)
-			
+			panel.size = get_clamped_size(viewport_ratio)
 			panel.position = get_pinned_position(pinned_position)
 			
 		InteractionState.DRAG:
@@ -156,9 +140,7 @@ func _process(_delta: float) -> void:
 	
 	# Sync camera settings.
 	if camera_type == CameraType.CAMERA_3D and selected_camera_3d:
-		# TODO: Don't think this is needed and can just assign `panel.size` directly.
-		var viewport_size = Vector2(panel.size.x, panel.size.x * viewport_ratio)
-		sub_viewport.size = viewport_size
+		sub_viewport.size = panel.size
 		
 		preview_camera_3d.fov = selected_camera_3d.fov
 		preview_camera_3d.projection = selected_camera_3d.projection
@@ -284,6 +266,18 @@ func get_pinned_position(pinned_position: PinnedPosition) -> Vector2:
 			assert(false, "Unknown pinned position %s" % str(pinned_position))
 			
 	return Vector2.ZERO
+	
+func get_clamped_size(viewport_ratio: float) -> Vector2:
+	# Constrain panel size to aspect ratio.
+	panel.size.y = panel.size.x * viewport_ratio
+	
+	# Clamp size.
+	panel.size = panel.size.clamp(
+		Vector2(min_panel_width * screen_scale, min_panel_width * screen_scale * viewport_ratio),
+		Vector2(size.x * max_panel_width_ratio, size.x * max_panel_width_ratio * viewport_ratio)
+	)
+	
+	return panel.size
 
 func _on_resize_handle_button_down() -> void:
 	if state != InteractionState.NONE: return

--- a/addons/anthonyec.camera_preview/preview.tscn
+++ b/addons/anthonyec.camera_preview/preview.tscn
@@ -1,9 +1,12 @@
-[gd_scene load_steps=7 format=3 uid="uid://xybmfvufjuv"]
+[gd_scene load_steps=8 format=3 uid="uid://xybmfvufjuv"]
 
 [ext_resource type="Script" path="res://addons/anthonyec.camera_preview/preview.gd" id="1_6b32r"]
 [ext_resource type="Texture2D" uid="uid://do6d60od41vmg" path="res://addons/anthonyec.camera_preview/Pin.svg" id="2_p0pa8"]
 [ext_resource type="Texture2D" uid="uid://btc01wc11tiid" path="res://addons/anthonyec.camera_preview/GuiResizerTopLeft.svg" id="2_t64ej"]
 [ext_resource type="Texture2D" uid="uid://04l05jxuyt7k" path="res://addons/anthonyec.camera_preview/GuiResizerTopRight.svg" id="3_6yuab"]
+
+[sub_resource type="ViewportTexture" id="ViewportTexture_j8c5h"]
+viewport_path = NodePath("Panel/SubViewport")
 
 [sub_resource type="Gradient" id="Gradient_11p6r"]
 offsets = PackedFloat32Array(0, 0.3, 0.6, 1)
@@ -90,7 +93,8 @@ theme_override_constants/margin_bottom = 4
 [node name="TextureRect" type="TextureRect" parent="Panel/ViewportMarginContainer"]
 unique_name_in_owner = true
 layout_mode = 2
-expand_mode = 2
+texture = SubResource("ViewportTexture_j8c5h")
+expand_mode = 1
 
 [node name="DragHandle" type="Button" parent="Panel"]
 layout_mode = 1


### PR DESCRIPTION
## Problem
Portrait aspect ratio was poorly supported. It'd look stretched and the borders on the left and right would disappear

## Changes
- Rewrite how the preview size is clamped and calculated. It now takes the editor viewport size into account both vertically and horizontally
- Remove sub-pixel artefacts by rounding the down the size to whole pixels

![image](https://github.com/anthonyec/godot_little_camera_preview/assets/1451668/73d4f60f-d57f-41b9-8609-0ff52482d448)

https://github.com/anthonyec/godot_little_camera_preview/assets/1451668/1f4586c8-bccd-4c0a-aff6-355d73cf1be0

_Sub-pixel problems, notice the wiggle_

https://github.com/anthonyec/godot_little_camera_preview/assets/1451668/1e1c2b04-668b-4a17-9832-bb7a0b73421f

_Rounding to nearest pixel_

--- 

Fixes: https://github.com/anthonyec/godot_little_camera_preview/issues/7