### PR TITLE
Fix UI scaling to use editor scale

### DIFF
--- a/addons/anthonyec.camera_preview/preview.gd
+++ b/addons/anthonyec.camera_preview/preview.gd
@@ -26,6 +26,7 @@ enum InteractionState {
 
 const margin_3d: Vector2 = Vector2(10, 10)
 const margin_2d: Vector2 = Vector2(20, 15)
+const panel_margin: float = 2
 const min_panel_width: float = 250
 const max_panel_width_ratio: float = 0.6
 
@@ -45,7 +46,7 @@ const max_panel_width_ratio: float = 0.6
 var camera_type: CameraType = CameraType.CAMERA_3D
 var pinned_position: PinnedPosition = PinnedPosition.RIGHT
 var viewport_ratio: float = 1
-var screen_scale: float = 1
+var editor_scale: float = EditorInterface.get_editor_scale()
 var is_locked: bool
 var show_controls: bool
 var selected_camera_3d: Camera3D
@@ -59,7 +60,8 @@ var initial_panel_size: Vector2
 var initial_panel_position: Vector2
 
 func _ready() -> void:
-	screen_scale = DisplayServer.screen_get_scale()
+	# Set initial width.
+	panel.size.x = min_panel_width * editor_scale
 	
 	# Setting texture to viewport in code instead of directly in the editor 
 	# because otherwise an error "Path to node is invalid: Panel/SubViewport"
@@ -81,12 +83,17 @@ func _ready() -> void:
 	#
 	# Maybe I don't know the correct way to do it, so for now the workaround is
 	# to set the correct size in code using screen scale.
-	var button_size = Vector2(30, 30) * screen_scale
-	var margin_size: float = 2 * screen_scale
+	var button_size = Vector2(30, 30) * editor_scale
+	var margin_size: float = panel_margin * editor_scale
 	
-	resize_left_handle.custom_minimum_size = button_size
-	resize_right_handle.custom_minimum_size = button_size
-	lock_button.custom_minimum_size = button_size
+	resize_left_handle.size = button_size
+	resize_left_handle.pivot_offset = Vector2(0, 0) * editor_scale
+	
+	resize_right_handle.size = button_size
+	resize_right_handle.pivot_offset = Vector2(30, 30) * editor_scale
+	
+	lock_button.size = button_size
+	lock_button.pivot_offset = Vector2(0, 30) * editor_scale
 	
 	viewport_margin_container.add_theme_constant_override("margin_left", margin_size)
 	viewport_margin_container.add_theme_constant_override("margin_top", margin_size)
@@ -112,7 +119,7 @@ func _process(_delta: float) -> void:
 			
 			# Clamp size.
 			panel.size = panel.size.clamp(
-				Vector2(min_panel_width * screen_scale, min_panel_width * screen_scale * viewport_ratio),
+				Vector2(min_panel_width * editor_scale, min_panel_width * editor_scale * viewport_ratio),
 				Vector2(size.x * max_panel_width_ratio, size.x * max_panel_width_ratio * viewport_ratio)
 			)
 			
@@ -132,7 +139,7 @@ func _process(_delta: float) -> void:
 			
 			# Clamp size.
 			panel.size = panel.size.clamp(
-				Vector2(min_panel_width * screen_scale, min_panel_width * screen_scale * viewport_ratio),
+				Vector2(min_panel_width * editor_scale, min_panel_width * editor_scale * viewport_ratio),
 				Vector2(size.x * max_panel_width_ratio, size.x * max_panel_width_ratio * viewport_ratio)
 			)
 			
@@ -301,10 +308,10 @@ func request_show() -> void:
 	visible = true
 	
 func get_pinned_position(pinned_position: PinnedPosition) -> Vector2:
-	var margin: Vector2 = margin_3d * screen_scale
+	var margin: Vector2 = margin_3d * editor_scale
 	
 	if camera_type == CameraType.CAMERA_2D:
-		margin = margin_2d * screen_scale
+		margin = margin_2d * editor_scale
 	
 	match pinned_position:
 		PinnedPosition.LEFT:

--- a/addons/anthonyec.camera_preview/preview.gd
+++ b/addons/anthonyec.camera_preview/preview.gd
@@ -42,6 +42,7 @@ const max_panel_width_ratio: float = 0.6
 @onready var gradient: TextureRect = %Gradient
 @onready var viewport_margin_container: MarginContainer = %ViewportMarginContainer
 @onready var overlay_margin_container: MarginContainer = %OverlayMarginContainer
+@onready var overlay_container: Control = %OverlayContainer
 
 var camera_type: CameraType = CameraType.CAMERA_3D
 var pinned_position: PinnedPosition = PinnedPosition.RIGHT
@@ -104,6 +105,21 @@ func _ready() -> void:
 	overlay_margin_container.add_theme_constant_override("margin_top", margin_size)
 	overlay_margin_container.add_theme_constant_override("margin_right", margin_size)
 	overlay_margin_container.add_theme_constant_override("margin_bottom", margin_size)
+	
+	# Parent node overlay size is not available on first ready, need to wait a 
+	# frame for it to be drawn.
+	await get_tree().process_frame
+	
+	# Anchors are set in code because setting them in the editor UI doesn't take
+	# editor scale into account.
+	resize_left_handle.position = Vector2(0, 0)
+	resize_right_handle.set_anchors_preset(Control.PRESET_TOP_LEFT)
+	
+	resize_right_handle.position = Vector2(overlay_container.size.x - button_size.x, 0)
+	resize_right_handle.set_anchors_preset(Control.PRESET_TOP_RIGHT)
+	
+	lock_button.position = Vector2(0, overlay_container.size.y - button_size.y)
+	lock_button.set_anchors_preset(Control.PRESET_BOTTOM_LEFT)
 
 func _process(_delta: float) -> void:
 	if not visible: return

--- a/addons/anthonyec.camera_preview/preview.tscn
+++ b/addons/anthonyec.camera_preview/preview.tscn
@@ -5,7 +5,7 @@
 [ext_resource type="Texture2D" uid="uid://btc01wc11tiid" path="res://addons/anthonyec.camera_preview/GuiResizerTopLeft.svg" id="2_t64ej"]
 [ext_resource type="Texture2D" uid="uid://04l05jxuyt7k" path="res://addons/anthonyec.camera_preview/GuiResizerTopRight.svg" id="3_6yuab"]
 
-[sub_resource type="ViewportTexture" id="ViewportTexture_2vshs"]
+[sub_resource type="ViewportTexture" id="ViewportTexture_8fgte"]
 viewport_path = NodePath("Panel/SubViewport")
 
 [sub_resource type="Gradient" id="Gradient_11p6r"]
@@ -94,22 +94,11 @@ theme_override_constants/margin_bottom = 4
 [node name="TextureRect" type="TextureRect" parent="Panel/ViewportMarginContainer"]
 unique_name_in_owner = true
 layout_mode = 2
-texture = SubResource("ViewportTexture_2vshs")
+texture = SubResource("ViewportTexture_8fgte")
 expand_mode = 2
-
-[node name="DragHandle" type="Button" parent="Panel"]
-layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-focus_mode = 0
-flat = true
 
 [node name="Gradient" type="TextureRect" parent="Panel"]
 unique_name_in_owner = true
-visible = false
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
@@ -121,7 +110,6 @@ texture = SubResource("GradientTexture2D_4dkve")
 
 [node name="OverlayMarginContainer" type="MarginContainer" parent="Panel"]
 unique_name_in_owner = true
-clip_contents = true
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
@@ -134,35 +122,63 @@ theme_override_constants/margin_top = 4
 theme_override_constants/margin_right = 4
 theme_override_constants/margin_bottom = 4
 
-[node name="ResizeLeftHandle" type="Button" parent="Panel/OverlayMarginContainer"]
-unique_name_in_owner = true
-visible = false
-custom_minimum_size = Vector2(60, 60)
+[node name="OverlayContainer" type="Control" parent="Panel/OverlayMarginContainer"]
+clip_contents = true
 layout_mode = 2
+mouse_filter = 2
+
+[node name="DragHandle" type="Button" parent="Panel/OverlayMarginContainer/OverlayContainer"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+focus_mode = 0
+flat = true
+
+[node name="ResizeLeftHandle" type="Button" parent="Panel/OverlayMarginContainer/OverlayContainer"]
+unique_name_in_owner = true
+layout_mode = 1
+offset_right = 60.0
+offset_bottom = 60.0
 size_flags_horizontal = 0
 size_flags_vertical = 0
 mouse_default_cursor_shape = 12
 icon = ExtResource("2_t64ej")
 flat = true
 icon_alignment = 1
+expand_icon = true
 
-[node name="ResizeRightHandle" type="Button" parent="Panel/OverlayMarginContainer"]
+[node name="ResizeRightHandle" type="Button" parent="Panel/OverlayMarginContainer/OverlayContainer"]
 unique_name_in_owner = true
 visible = false
-custom_minimum_size = Vector2(60, 60)
-layout_mode = 2
+layout_mode = 1
+anchors_preset = 1
+anchor_left = 1.0
+anchor_right = 1.0
+offset_left = -60.0
+offset_bottom = 60.0
+grow_horizontal = 0
+pivot_offset = Vector2(60, 60)
 size_flags_horizontal = 8
 size_flags_vertical = 0
 mouse_default_cursor_shape = 11
 icon = ExtResource("3_6yuab")
 flat = true
 icon_alignment = 1
+expand_icon = true
 
-[node name="LockButton" type="Button" parent="Panel/OverlayMarginContainer"]
+[node name="LockButton" type="Button" parent="Panel/OverlayMarginContainer/OverlayContainer"]
 unique_name_in_owner = true
-visible = false
-custom_minimum_size = Vector2(60, 60)
-layout_mode = 2
+layout_mode = 1
+anchors_preset = 2
+anchor_top = 1.0
+anchor_bottom = 1.0
+offset_top = -60.0
+offset_right = 60.0
+grow_vertical = 0
+pivot_offset = Vector2(0, 60)
 size_flags_horizontal = 0
 size_flags_vertical = 8
 tooltip_text = "Always Show Preview"
@@ -170,12 +186,13 @@ toggle_mode = true
 icon = ExtResource("2_p0pa8")
 flat = true
 icon_alignment = 1
+expand_icon = true
 
-[connection signal="button_down" from="Panel/DragHandle" to="." method="_on_drag_handle_button_down"]
-[connection signal="button_up" from="Panel/DragHandle" to="." method="_on_drag_handle_button_up"]
-[connection signal="renamed" from="Panel/DragHandle" to="." method="_on_drag_handle_renamed"]
-[connection signal="button_down" from="Panel/OverlayMarginContainer/ResizeLeftHandle" to="." method="_on_resize_handle_button_down"]
-[connection signal="button_up" from="Panel/OverlayMarginContainer/ResizeLeftHandle" to="." method="_on_resize_handle_button_up"]
-[connection signal="button_down" from="Panel/OverlayMarginContainer/ResizeRightHandle" to="." method="_on_resize_handle_button_down"]
-[connection signal="button_up" from="Panel/OverlayMarginContainer/ResizeRightHandle" to="." method="_on_resize_handle_button_up"]
-[connection signal="pressed" from="Panel/OverlayMarginContainer/LockButton" to="." method="_on_lock_button_pressed"]
+[connection signal="button_down" from="Panel/OverlayMarginContainer/OverlayContainer/DragHandle" to="." method="_on_drag_handle_button_down"]
+[connection signal="button_up" from="Panel/OverlayMarginContainer/OverlayContainer/DragHandle" to="." method="_on_drag_handle_button_up"]
+[connection signal="renamed" from="Panel/OverlayMarginContainer/OverlayContainer/DragHandle" to="." method="_on_drag_handle_renamed"]
+[connection signal="button_down" from="Panel/OverlayMarginContainer/OverlayContainer/ResizeLeftHandle" to="." method="_on_resize_handle_button_down"]
+[connection signal="button_up" from="Panel/OverlayMarginContainer/OverlayContainer/ResizeLeftHandle" to="." method="_on_resize_handle_button_up"]
+[connection signal="button_down" from="Panel/OverlayMarginContainer/OverlayContainer/ResizeRightHandle" to="." method="_on_resize_handle_button_down"]
+[connection signal="button_up" from="Panel/OverlayMarginContainer/OverlayContainer/ResizeRightHandle" to="." method="_on_resize_handle_button_up"]
+[connection signal="pressed" from="Panel/OverlayMarginContainer/OverlayContainer/LockButton" to="." method="_on_lock_button_pressed"]

--- a/addons/anthonyec.camera_preview/preview.tscn
+++ b/addons/anthonyec.camera_preview/preview.tscn
@@ -5,7 +5,7 @@
 [ext_resource type="Texture2D" uid="uid://btc01wc11tiid" path="res://addons/anthonyec.camera_preview/GuiResizerTopLeft.svg" id="2_t64ej"]
 [ext_resource type="Texture2D" uid="uid://04l05jxuyt7k" path="res://addons/anthonyec.camera_preview/GuiResizerTopRight.svg" id="3_6yuab"]
 
-[sub_resource type="ViewportTexture" id="ViewportTexture_8fgte"]
+[sub_resource type="ViewportTexture" id="ViewportTexture_wp8cj"]
 viewport_path = NodePath("Panel/SubViewport")
 
 [sub_resource type="Gradient" id="Gradient_11p6r"]
@@ -94,11 +94,12 @@ theme_override_constants/margin_bottom = 4
 [node name="TextureRect" type="TextureRect" parent="Panel/ViewportMarginContainer"]
 unique_name_in_owner = true
 layout_mode = 2
-texture = SubResource("ViewportTexture_8fgte")
+texture = SubResource("ViewportTexture_wp8cj")
 expand_mode = 2
 
 [node name="Gradient" type="TextureRect" parent="Panel"]
 unique_name_in_owner = true
+visible = false
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
@@ -123,6 +124,7 @@ theme_override_constants/margin_right = 4
 theme_override_constants/margin_bottom = 4
 
 [node name="OverlayContainer" type="Control" parent="Panel/OverlayMarginContainer"]
+unique_name_in_owner = true
 clip_contents = true
 layout_mode = 2
 mouse_filter = 2
@@ -139,6 +141,7 @@ flat = true
 
 [node name="ResizeLeftHandle" type="Button" parent="Panel/OverlayMarginContainer/OverlayContainer"]
 unique_name_in_owner = true
+visible = false
 layout_mode = 1
 offset_right = 60.0
 offset_bottom = 60.0
@@ -154,12 +157,9 @@ expand_icon = true
 unique_name_in_owner = true
 visible = false
 layout_mode = 1
-anchors_preset = 1
-anchor_left = 1.0
-anchor_right = 1.0
-offset_left = -60.0
+offset_left = 432.0
+offset_right = 492.0
 offset_bottom = 60.0
-grow_horizontal = 0
 pivot_offset = Vector2(60, 60)
 size_flags_horizontal = 8
 size_flags_vertical = 0
@@ -171,13 +171,11 @@ expand_icon = true
 
 [node name="LockButton" type="Button" parent="Panel/OverlayMarginContainer/OverlayContainer"]
 unique_name_in_owner = true
+visible = false
 layout_mode = 1
-anchors_preset = 2
-anchor_top = 1.0
-anchor_bottom = 1.0
-offset_top = -60.0
+offset_top = 213.0
 offset_right = 60.0
-grow_vertical = 0
+offset_bottom = 273.0
 pivot_offset = Vector2(0, 60)
 size_flags_horizontal = 0
 size_flags_vertical = 8

--- a/addons/anthonyec.camera_preview/preview.tscn
+++ b/addons/anthonyec.camera_preview/preview.tscn
@@ -1,9 +1,12 @@
-[gd_scene load_steps=7 format=3 uid="uid://xybmfvufjuv"]
+[gd_scene load_steps=8 format=3 uid="uid://xybmfvufjuv"]
 
 [ext_resource type="Script" path="res://addons/anthonyec.camera_preview/preview.gd" id="1_6b32r"]
 [ext_resource type="Texture2D" uid="uid://do6d60od41vmg" path="res://addons/anthonyec.camera_preview/Pin.svg" id="2_p0pa8"]
 [ext_resource type="Texture2D" uid="uid://btc01wc11tiid" path="res://addons/anthonyec.camera_preview/GuiResizerTopLeft.svg" id="2_t64ej"]
 [ext_resource type="Texture2D" uid="uid://04l05jxuyt7k" path="res://addons/anthonyec.camera_preview/GuiResizerTopRight.svg" id="3_6yuab"]
+
+[sub_resource type="ViewportTexture" id="ViewportTexture_2vshs"]
+viewport_path = NodePath("Panel/SubViewport")
 
 [sub_resource type="Gradient" id="Gradient_11p6r"]
 offsets = PackedFloat32Array(0, 0.3, 0.6, 1)
@@ -74,6 +77,7 @@ unique_name_in_owner = true
 ignore_rotation = false
 
 [node name="ViewportMarginContainer" type="MarginContainer" parent="Panel"]
+unique_name_in_owner = true
 clip_contents = true
 layout_mode = 1
 anchors_preset = 15
@@ -90,6 +94,7 @@ theme_override_constants/margin_bottom = 4
 [node name="TextureRect" type="TextureRect" parent="Panel/ViewportMarginContainer"]
 unique_name_in_owner = true
 layout_mode = 2
+texture = SubResource("ViewportTexture_2vshs")
 expand_mode = 2
 
 [node name="DragHandle" type="Button" parent="Panel"]
@@ -115,6 +120,7 @@ mouse_filter = 2
 texture = SubResource("GradientTexture2D_4dkve")
 
 [node name="OverlayMarginContainer" type="MarginContainer" parent="Panel"]
+unique_name_in_owner = true
 clip_contents = true
 layout_mode = 1
 anchors_preset = 15
@@ -131,6 +137,7 @@ theme_override_constants/margin_bottom = 4
 [node name="ResizeLeftHandle" type="Button" parent="Panel/OverlayMarginContainer"]
 unique_name_in_owner = true
 visible = false
+custom_minimum_size = Vector2(60, 60)
 layout_mode = 2
 size_flags_horizontal = 0
 size_flags_vertical = 0
@@ -142,6 +149,7 @@ icon_alignment = 1
 [node name="ResizeRightHandle" type="Button" parent="Panel/OverlayMarginContainer"]
 unique_name_in_owner = true
 visible = false
+custom_minimum_size = Vector2(60, 60)
 layout_mode = 2
 size_flags_horizontal = 8
 size_flags_vertical = 0
@@ -153,7 +161,7 @@ icon_alignment = 1
 [node name="LockButton" type="Button" parent="Panel/OverlayMarginContainer"]
 unique_name_in_owner = true
 visible = false
-custom_minimum_size = Vector2(40, 40)
+custom_minimum_size = Vector2(60, 60)
 layout_mode = 2
 size_flags_horizontal = 0
 size_flags_vertical = 8


### PR DESCRIPTION
## Problem

The UI was never meant to be this chunky holy moly. But for people with 1x displays it was. This is because I work on a 2x display (retina) and assumed Godot automatically scaled the UI. Turns out it doesn't, at least for editor plugin UIs.

![image](https://github.com/anthonyec/godot_little_camera_preview/assets/1451668/a4aef999-8205-4c81-91d9-a68e4e5f749b)

## Changes

- Restructure overlay that contains buttons so that margin works correctly
- Ensure anchor presets works correctly and is set in code to take advantage of editor scale
- Ensure button and margin sizes are scaled using editor scale
- Rename `screen_scale` to `editor_scale` since this is what Dialogic does

![Screenshot 2024-02-03 at 00 51 13](https://github.com/anthonyec/godot_little_camera_preview/assets/1451668/cfdb5126-ea13-4dea-b118-74d3347efc89)

_1x display_

<img width="1756" alt="Screenshot 2024-02-03 at 00 52 35" src="https://github.com/anthonyec/godot_little_camera_preview/assets/1451668/efa7662c-302b-4c8a-8b21-04cb0988ea83">

_2x display_
