### PR TITLE
Check selected nodes' children for Cameras

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .godot/
 .DS_Store
+.vscode/

--- a/addons/anthonyec.camera_preview/plugin.cfg
+++ b/addons/anthonyec.camera_preview/plugin.cfg
@@ -3,5 +3,5 @@
 name="Little Camera Preview"
 description="Shows a picture-in-picture preview of the selected 2D or 3D camera"
 author="Anthony Cossins"
-version="1.3"
+version="1.4"
 script="plugin.gd"

--- a/addons/anthonyec.camera_preview/plugin.gd
+++ b/addons/anthonyec.camera_preview/plugin.gd
@@ -46,42 +46,52 @@ func _on_editor_selection_changed() -> void:
 	
 	var selected_nodes: Array[Node] = EditorInterface.get_selection().get_selected_nodes()
 	
-	var selected_camera_3d: Camera3D = find_camera_3d_or_null(selected_nodes)
-	var selected_camera_2d: Camera2D = find_camera_2d_or_null(selected_nodes)
-	
-	if selected_camera_3d and current_main_screen_name == "3D":
-		preview.link_with_camera_3d(selected_camera_3d)
-		preview.request_show()
-	
-	elif selected_camera_2d and current_main_screen_name == "2D":
-		preview.link_with_camera_2d(selected_camera_2d)
-		preview.request_show()
-		
-	else:
+	if selected_nodes.is_empty():
 		preview.request_hide()
+		return
+		
+	var camera_3d: Camera3D
+	var camera_2d: Camera2D
+	
+	if current_main_screen_name == "3D":
+		for node in selected_nodes:
+			camera_3d = find_camera_3d(node)
+			if camera_3d:
+				preview.link_with_camera_3d(camera_3d)
+				preview.request_show()
+				return
+	elif current_main_screen_name == "2D":	
+		for node in selected_nodes:
+			camera_2d = find_camera_2d(node)
+			if camera_2d:
+				preview.link_with_camera_2d(camera_2d)
+				preview.request_show()
+				return
+	
+	preview.request_hide()
 	
 func is_main_screen_viewport() -> bool:
 	return current_main_screen_name == "3D" or current_main_screen_name == "2D"
 	
-func find_camera_3d_or_null(nodes: Array[Node]) -> Camera3D:
-	var camera: Camera3D
+func find_camera_3d(node: Node) -> Camera3D:
+	if node is Camera3D:
+		return node as Camera3D
+		
+	var children = node.find_children("*", "Camera3D")
+	if not children.is_empty():
+		return children[0] as Camera3D
+		
+	return null
 	
-	for node in nodes:
-		if node is Camera3D:
-			camera = node as Camera3D
-			break
-			
-	return camera
-	
-func find_camera_2d_or_null(nodes: Array[Node]) -> Camera2D:
-	var camera: Camera2D
-	
-	for node in nodes:
-		if node is Camera2D:
-			camera = node as Camera2D
-			break
-			
-	return camera
+func find_camera_2d(node: Node) -> Camera2D:
+	if node is Camera2D:
+		return node as Camera2D
+		
+	var children = node.find_children("*", "Camera2D")
+	if not children.is_empty():
+		return children[0] as Camera2D
+		
+	return null
 
 func _on_selected_camera_3d_tree_exiting() -> void:
 	preview.unlink_camera()

--- a/addons/anthonyec.camera_preview/plugin.gd
+++ b/addons/anthonyec.camera_preview/plugin.gd
@@ -14,7 +14,7 @@ func _enter_tree() -> void:
 	preview = preview_scene.instantiate() as CameraPreview
 	preview.request_hide()
 	
-	var main_screen = EditorInterface.get_editor_main_screen()
+	var main_screen: Control = EditorInterface.get_editor_main_screen() as Control
 	main_screen.add_child(preview)
 	
 func _exit_tree() -> void:
@@ -44,7 +44,7 @@ func _on_editor_selection_changed() -> void:
 		
 	preview.visible = true
 	
-	var selected_nodes = EditorInterface.get_selection().get_selected_nodes()
+	var selected_nodes: Array[Node] = EditorInterface.get_selection().get_selected_nodes()
 	
 	var selected_camera_3d: Camera3D = find_camera_3d_or_null(selected_nodes)
 	var selected_camera_2d: Camera2D = find_camera_2d_or_null(selected_nodes)

--- a/addons/anthonyec.camera_preview/plugin.gd.uid
+++ b/addons/anthonyec.camera_preview/plugin.gd.uid
@@ -1,0 +1,1 @@
+uid://dgq70e0pxlh61

--- a/addons/anthonyec.camera_preview/preview.gd
+++ b/addons/anthonyec.camera_preview/preview.gd
@@ -233,6 +233,13 @@ func _process(_delta: float) -> void:
 		preview_camera_2d.limit_right = _selected_camera_2d.limit_right
 		preview_camera_2d.limit_top = _selected_camera_2d.limit_top
 		preview_camera_2d.limit_bottom = _selected_camera_2d.limit_bottom
+		
+func _input(event: InputEvent) -> void:
+	var mouse_button_event: InputEventMouseButton = event as InputEventMouseButton
+	if not mouse_button_event: return
+	
+	if mouse_button_event.is_released() and mouse_button_event.button_index == MOUSE_BUTTON_LEFT:
+		_on_mouse_button_up()
 
 func link_with_camera_3d(camera_3d: Camera3D) -> void:
 	# TODO: Camera may not be ready since this method is called in `_enter_tree` 
@@ -387,7 +394,9 @@ func _on_resize_handle_button_down() -> void:
 	_initial_mouse_position = get_global_mouse_position()
 	_initial_panel_size = panel.size
 
-func _on_resize_handle_button_up() -> void:
+func _on_mouse_button_up() -> void:
+	if _state != InteractionState.RESIZE: return
+	
 	_state = InteractionState.NONE
 
 func _on_drag_handle_button_down() -> void:

--- a/addons/anthonyec.camera_preview/preview.gd
+++ b/addons/anthonyec.camera_preview/preview.gd
@@ -18,16 +18,16 @@ enum InteractionState {
 	RESIZE,
 	DRAG,
 
-	# Animation is split into 2 seperate states so that the tween is only 
+	# Animation is split into 2 separate states so that the tween is only 
 	# invoked once in the "start" state. 
 	START_ANIMATE_INTO_PLACE,
 	ANIMATE_INTO_PLACE,
 }
 
-const margin_3d: Vector2 = Vector2(10, 10)
-const margin_2d: Vector2 = Vector2(20, 15)
-const panel_margin: float = 2
-const min_panel_size: float = 250
+const MARGIN_3D: Vector2 = Vector2(10, 10)
+const MARGIN_2D: Vector2 = Vector2(20, 15)
+const PANEL_MARGIN: float = 2
+const MIN_PANEL_SIZE: float = 250
 
 @onready var panel: Panel = %Panel
 @onready var placeholder: Panel = %Placeholder
@@ -43,23 +43,22 @@ const min_panel_size: float = 250
 @onready var overlay_margin_container: MarginContainer = %OverlayMarginContainer
 @onready var overlay_container: Control = %OverlayContainer
 
-var camera_type: CameraType = CameraType.CAMERA_3D
-var pinned_position: PinnedPosition = PinnedPosition.RIGHT
-var viewport_ratio: float = 1
-var editor_scale: float = EditorInterface.get_editor_scale()
-var is_locked: bool
-var show_controls: bool
-var selected_camera_3d: Camera3D
-var selected_camera_2d: Camera2D
+var _camera_type: CameraType = CameraType.CAMERA_3D
+var _pinned_position: PinnedPosition = PinnedPosition.RIGHT
+var _editor_scale: float = EditorInterface.get_editor_scale()
+var _is_locked: bool
+var _show_controls: bool
+var _selected_camera_3d: Camera3D
+var _selected_camera_2d: Camera2D
 
-var state: InteractionState = InteractionState.NONE
-var initial_mouse_position: Vector2
-var initial_panel_size: Vector2
-var initial_panel_position: Vector2
+var _state: InteractionState = InteractionState.NONE
+var _initial_mouse_position: Vector2
+var _initial_panel_size: Vector2
+var _initial_panel_position: Vector2
 
 func _ready() -> void:
 	# Set initial width.
-	panel.size.x = min_panel_size * editor_scale
+	panel.size.x = MIN_PANEL_SIZE * _editor_scale
 	
 	# Setting texture to viewport in code instead of directly in the editor 
 	# because otherwise an error "Path to node is invalid: Panel/SubViewport"
@@ -81,17 +80,17 @@ func _ready() -> void:
 	#
 	# Maybe I don't know the correct way to do it, so for now the workaround is
 	# to set the correct size in code using screen scale.
-	var button_size = Vector2(30, 30) * editor_scale
-	var margin_size: float = panel_margin * editor_scale
+	var button_size: Vector2 = Vector2(30, 30) * _editor_scale
+	var margin_size: int = int(PANEL_MARGIN * _editor_scale)
 	
 	resize_left_handle.size = button_size
-	resize_left_handle.pivot_offset = Vector2(0, 0) * editor_scale
+	resize_left_handle.pivot_offset = Vector2(0, 0) * _editor_scale
 	
 	resize_right_handle.size = button_size
-	resize_right_handle.pivot_offset = Vector2(30, 30) * editor_scale
+	resize_right_handle.pivot_offset = Vector2(30, 30) * _editor_scale
 	
 	lock_button.size = button_size
-	lock_button.pivot_offset = Vector2(0, 30) * editor_scale
+	lock_button.pivot_offset = Vector2(0, 30) * _editor_scale
 	
 	viewport_margin_container.add_theme_constant_override("margin_left", margin_size)
 	viewport_margin_container.add_theme_constant_override("margin_top", margin_size)
@@ -121,73 +120,73 @@ func _ready() -> void:
 func _process(_delta: float) -> void:
 	if not visible: return
 	
-	match state:
+	match _state:
 		InteractionState.NONE:
 			panel.size = get_clamped_size(panel.size)
-			panel.position = get_pinned_position(pinned_position)
+			panel.position = get_pinned_position(_pinned_position)
 			
 		InteractionState.RESIZE:
-			var delta_mouse_position = initial_mouse_position - get_global_mouse_position()
-			var resized_size = panel.size
+			var delta_mouse_position: Vector2 = _initial_mouse_position - get_global_mouse_position()
+			var resized_size: Vector2 = panel.size
 		
-			if pinned_position == PinnedPosition.LEFT:
-				resized_size = initial_panel_size - delta_mouse_position
+			if _pinned_position == PinnedPosition.LEFT:
+				resized_size = _initial_panel_size - delta_mouse_position
 				
-			if pinned_position == PinnedPosition.RIGHT:
-				resized_size = initial_panel_size + delta_mouse_position
+			if _pinned_position == PinnedPosition.RIGHT:
+				resized_size = _initial_panel_size + delta_mouse_position
 			
 			panel.size = get_clamped_size(resized_size)
-			panel.position = get_pinned_position(pinned_position)
+			panel.position = get_pinned_position(_pinned_position)
 			
 		InteractionState.DRAG:
 			placeholder.size = panel.size
 			
-			var global_mouse_position = get_global_mouse_position()
-			var offset = initial_mouse_position - initial_panel_position
+			var global_mouse_position: Vector2 = get_global_mouse_position()
+			var offset: Vector2 = _initial_mouse_position - _initial_panel_position
 
 			panel.global_position = global_mouse_position - offset
 
 			if global_mouse_position.x < global_position.x + size.x / 2:
-				pinned_position = PinnedPosition.LEFT
+				_pinned_position = PinnedPosition.LEFT
 			else:
-				pinned_position = PinnedPosition.RIGHT
+				_pinned_position = PinnedPosition.RIGHT
 				
-			placeholder.position = get_pinned_position(pinned_position)
+			placeholder.position = get_pinned_position(_pinned_position)
 			
 		InteractionState.START_ANIMATE_INTO_PLACE:
-			var final_position: Vector2 = get_pinned_position(pinned_position)
-			var tween = get_tree().create_tween()
+			var final_position: Vector2 = get_pinned_position(_pinned_position)
+			var tween: Tween = get_tree().create_tween()
 			
 			tween.set_ease(Tween.EASE_OUT)
 			tween.set_trans(Tween.TRANS_CUBIC)
 			tween.tween_property(panel, "position", final_position, 0.3)
 			
-			tween.finished.connect(func():
+			tween.finished.connect(func() -> void:
 				panel.position = final_position
-				state = InteractionState.NONE
+				_state = InteractionState.NONE
 			)
 			
-			state = InteractionState.ANIMATE_INTO_PLACE
+			_state = InteractionState.ANIMATE_INTO_PLACE
 			
 	# I couldn't get `mouse_entered` and `mouse_exited` events to work 
 	# nicely, so I use rect method instead. Plus using this method it's easy to
 	# grow the hit area size.
-	var panel_hover_rect = Rect2(panel.global_position, panel.size)
+	var panel_hover_rect: Rect2 = Rect2(panel.global_position, panel.size)
 	panel_hover_rect = panel_hover_rect.grow(40)
 	
-	var mouse_position = get_global_mouse_position()
+	var mouse_position: Vector2 = get_global_mouse_position()
 	
-	show_controls = state != InteractionState.NONE or panel_hover_rect.has_point(mouse_position)
+	_show_controls = _state != InteractionState.NONE or panel_hover_rect.has_point(mouse_position)
 	
 	# UI visibility.
-	resize_left_handle.visible = show_controls and pinned_position == PinnedPosition.RIGHT
-	resize_right_handle.visible = show_controls and pinned_position == PinnedPosition.LEFT
-	lock_button.visible = show_controls or is_locked
-	placeholder.visible = state == InteractionState.DRAG or state == InteractionState.ANIMATE_INTO_PLACE
-	gradient.visible = show_controls
+	resize_left_handle.visible = _show_controls and _pinned_position == PinnedPosition.RIGHT
+	resize_right_handle.visible = _show_controls and _pinned_position == PinnedPosition.LEFT
+	lock_button.visible = _show_controls or _is_locked
+	placeholder.visible = _state == InteractionState.DRAG or _state == InteractionState.ANIMATE_INTO_PLACE
+	gradient.visible = _show_controls
 	
 	# Sync camera settings.
-	if camera_type == CameraType.CAMERA_3D and selected_camera_3d:
+	if _camera_type == CameraType.CAMERA_3D and _selected_camera_3d:
 		sub_viewport.size = panel.size
 		
 		# Sync position and rotation without using a `RemoteTransform` node 
@@ -195,45 +194,45 @@ func _process(_delta: float) -> void:
 		# be stored within the scene. Also it's harder to keep the remote 
 		# transform `remote_path` up-to-date with scene changes, which causes 
 		# many errors.
-		preview_camera_3d.global_position = selected_camera_3d.global_position
-		preview_camera_3d.global_rotation = selected_camera_3d.global_rotation
+		preview_camera_3d.global_position = _selected_camera_3d.global_position
+		preview_camera_3d.global_rotation = _selected_camera_3d.global_rotation
 		
-		preview_camera_3d.fov = selected_camera_3d.fov
-		preview_camera_3d.projection = selected_camera_3d.projection
-		preview_camera_3d.size = selected_camera_3d.size
-		preview_camera_3d.cull_mask = selected_camera_3d.cull_mask
-		preview_camera_3d.keep_aspect = selected_camera_3d.keep_aspect
-		preview_camera_3d.near = selected_camera_3d.near
-		preview_camera_3d.far = selected_camera_3d.far
-		preview_camera_3d.h_offset = selected_camera_3d.h_offset
-		preview_camera_3d.v_offset = selected_camera_3d.v_offset
-		preview_camera_3d.attributes = selected_camera_3d.attributes
-		preview_camera_3d.environment = selected_camera_3d.environment
+		preview_camera_3d.fov = _selected_camera_3d.fov
+		preview_camera_3d.projection = _selected_camera_3d.projection
+		preview_camera_3d.size = _selected_camera_3d.size
+		preview_camera_3d.cull_mask = _selected_camera_3d.cull_mask
+		preview_camera_3d.keep_aspect = _selected_camera_3d.keep_aspect
+		preview_camera_3d.near = _selected_camera_3d.near
+		preview_camera_3d.far = _selected_camera_3d.far
+		preview_camera_3d.h_offset = _selected_camera_3d.h_offset
+		preview_camera_3d.v_offset = _selected_camera_3d.v_offset
+		preview_camera_3d.attributes = _selected_camera_3d.attributes
+		preview_camera_3d.environment = _selected_camera_3d.environment
 	
-	if camera_type == CameraType.CAMERA_2D and selected_camera_2d:
-		var project_window_size = get_project_window_size()
-		var ratio = project_window_size.x / panel.size.x
+	if _camera_type == CameraType.CAMERA_2D and _selected_camera_2d:
+		var project_window_size: Vector2 = get_project_window_size()
+		var ratio: float = project_window_size.x / panel.size.x
 		
 		# TODO: Is there a better way to fix this?
 		# The camera border is visible sometimes due to pixel rounding. 
 		# Subtract 1px from right and bottom to hide this.
-		var hide_camera_border_fix = Vector2(1, 1)
+		var hide_camera_border_fix: Vector2 = Vector2(1, 1)
 		
 		sub_viewport.size = panel.size
 		sub_viewport.size_2d_override = (panel.size - hide_camera_border_fix) * ratio
 		sub_viewport.size_2d_override_stretch = true
 		
-		preview_camera_2d.global_position = selected_camera_2d.global_position
-		preview_camera_2d.global_rotation = selected_camera_2d.global_rotation
+		preview_camera_2d.global_position = _selected_camera_2d.global_position
+		preview_camera_2d.global_rotation = _selected_camera_2d.global_rotation
 
-		preview_camera_2d.offset = selected_camera_2d.offset
-		preview_camera_2d.zoom = selected_camera_2d.zoom
-		preview_camera_2d.ignore_rotation = selected_camera_2d.ignore_rotation
-		preview_camera_2d.anchor_mode = selected_camera_2d.anchor_mode
-		preview_camera_2d.limit_left = selected_camera_2d.limit_left
-		preview_camera_2d.limit_right = selected_camera_2d.limit_right
-		preview_camera_2d.limit_top = selected_camera_2d.limit_top
-		preview_camera_2d.limit_bottom = selected_camera_2d.limit_bottom
+		preview_camera_2d.offset = _selected_camera_2d.offset
+		preview_camera_2d.zoom = _selected_camera_2d.zoom
+		preview_camera_2d.ignore_rotation = _selected_camera_2d.ignore_rotation
+		preview_camera_2d.anchor_mode = _selected_camera_2d.anchor_mode
+		preview_camera_2d.limit_left = _selected_camera_2d.limit_left
+		preview_camera_2d.limit_right = _selected_camera_2d.limit_right
+		preview_camera_2d.limit_top = _selected_camera_2d.limit_top
+		preview_camera_2d.limit_bottom = _selected_camera_2d.limit_bottom
 
 func link_with_camera_3d(camera_3d: Camera3D) -> void:
 	# TODO: Camera may not be ready since this method is called in `_enter_tree` 
@@ -242,7 +241,7 @@ func link_with_camera_3d(camera_3d: Camera3D) -> void:
 	if not preview_camera_3d:
 		return request_hide()
 		
-	var is_different_camera = camera_3d != preview_camera_3d
+	var is_different_camera: bool = camera_3d != preview_camera_3d
 	
 	# TODO: A bit messy.
 	if is_different_camera:
@@ -255,14 +254,14 @@ func link_with_camera_3d(camera_3d: Camera3D) -> void:
 	sub_viewport.disable_3d = false
 	sub_viewport.world_3d = camera_3d.get_world_3d()
 	
-	selected_camera_3d = camera_3d
-	camera_type = CameraType.CAMERA_3D
+	_selected_camera_3d = camera_3d
+	_camera_type = CameraType.CAMERA_3D
 	
 func link_with_camera_2d(camera_2d: Camera2D) -> void:
 	if not preview_camera_2d:
 		return request_hide()
 	
-	var is_different_camera = camera_2d != preview_camera_2d
+	var is_different_camera: bool = camera_2d != preview_camera_2d
 	
 	# TODO: A bit messy.
 	if is_different_camera:
@@ -275,31 +274,31 @@ func link_with_camera_2d(camera_2d: Camera2D) -> void:
 	sub_viewport.disable_3d = true
 	sub_viewport.world_2d = camera_2d.get_world_2d()
 		
-	selected_camera_2d = camera_2d
-	camera_type = CameraType.CAMERA_2D
+	_selected_camera_2d = camera_2d
+	_camera_type = CameraType.CAMERA_2D
 
 func unlink_camera() -> void:
-	if selected_camera_3d:
-		selected_camera_3d = null
+	if _selected_camera_3d:
+		_selected_camera_3d = null
 	
-	if selected_camera_2d:
-		selected_camera_2d = null
+	if _selected_camera_2d:
+		_selected_camera_2d = null
 	
-	is_locked = false
+	_is_locked = false
 	lock_button.button_pressed = false
 	
 func request_hide() -> void:
-	if is_locked: return
+	if _is_locked: return
 	visible = false
 	
 func request_show() -> void:
 	visible = true
 	
 func get_pinned_position(pinned_position: PinnedPosition) -> Vector2:
-	var margin: Vector2 = margin_3d * editor_scale
+	var margin: Vector2 = MARGIN_3D * _editor_scale
 	
-	if camera_type == CameraType.CAMERA_2D:
-		margin = margin_2d * editor_scale
+	if _camera_type == CameraType.CAMERA_2D:
+		margin = MARGIN_2D * _editor_scale
 	
 	match pinned_position:
 		PinnedPosition.LEFT:
@@ -312,15 +311,15 @@ func get_pinned_position(pinned_position: PinnedPosition) -> Vector2:
 	return Vector2.ZERO
 	
 func get_clamped_size(desired_size: Vector2) -> Vector2:
-	var viewport_ratio = get_project_window_ratio()
-	var editor_viewport_size = get_editor_viewport_size()
+	var viewport_ratio: float = get_project_window_ratio()
+	var editor_viewport_size: Vector2 = get_editor_viewport_size()
 
-	var max_bounds = Vector2(
+	var max_bounds: Vector2 = Vector2(
 		editor_viewport_size.x * 0.6,
 		editor_viewport_size.y * 0.8
 	)
 	
-	var clamped_size = desired_size
+	var clamped_size: Vector2 = desired_size
 	
 	# Apply aspect ratio.
 	clamped_size = Vector2(clamped_size.x, clamped_size.x * viewport_ratio)
@@ -337,68 +336,71 @@ func get_clamped_size(desired_size: Vector2) -> Vector2:
 	# Clamp the min size based on if it's portrait or landscape. Portrait min
 	# size should be based on it's height. Landscape min size is based on it's
 	# width instead. Applying min width to a portrait size would make it too big.
-	var is_portrait = viewport_ratio > 1
+	var is_portrait: bool = viewport_ratio > 1
 	
-	if is_portrait and clamped_size.y <= min_panel_size * editor_scale:
-		clamped_size.x = min_panel_size / viewport_ratio
-		clamped_size.y = min_panel_size
-		clamped_size = clamped_size * editor_scale
+	if is_portrait and clamped_size.y <= MIN_PANEL_SIZE * _editor_scale:
+		clamped_size.x = MIN_PANEL_SIZE / viewport_ratio
+		clamped_size.y = MIN_PANEL_SIZE
+		clamped_size = clamped_size * _editor_scale
 		
-	if not is_portrait and clamped_size.x <= min_panel_size * editor_scale:
-		clamped_size.x = min_panel_size
-		clamped_size.y = min_panel_size * viewport_ratio
-		clamped_size = clamped_size * editor_scale
+	if not is_portrait and clamped_size.x <= MIN_PANEL_SIZE * _editor_scale:
+		clamped_size.x = MIN_PANEL_SIZE
+		clamped_size.y = MIN_PANEL_SIZE * viewport_ratio
+		clamped_size = clamped_size * _editor_scale
 	
 	# Round down to avoid sub-pixel artifacts, mainly seen around the margins.
 	return clamped_size.floor()
 	
 func get_project_window_size() -> Vector2:
-	var window_width = float(ProjectSettings.get_setting("display/window/size/viewport_width"))
-	var window_height = float(ProjectSettings.get_setting("display/window/size/viewport_height"))
+	var window_width: float = float(ProjectSettings.get_setting("display/window/size/viewport_width"))
+	var window_height: float = float(ProjectSettings.get_setting("display/window/size/viewport_height"))
 	
 	return Vector2(window_width, window_height)
 	
 func get_project_window_ratio() -> float:
-	var project_window_size = get_project_window_size()
+	var project_window_size: Vector2 = get_project_window_size()
 	
 	return project_window_size.y / project_window_size.x
 	
 func get_editor_viewport_size() -> Vector2:
-	var fallback_size = EditorInterface.get_editor_main_screen().size
+	var fallback_size: Vector2 = EditorInterface.get_editor_main_screen().size
 	
 	# There isn't an API for getting the viewport node. Instead it has to be
 	# found by checking the parent's parent of the subviewport and find
 	# the correct node based on name and class.
-	var editor_sub_viewport_3d = EditorInterface.get_editor_viewport_3d(0)
-	var editor_viewport_container = editor_sub_viewport_3d.get_parent().get_parent().get_parent()
+	var editor_sub_viewport_3d: SubViewport = EditorInterface.get_editor_viewport_3d(0)
+	var editor_viewport_container: Control = editor_sub_viewport_3d.get_parent().get_parent().get_parent() as Control
 	
-	# Early return incase editor tree structure has changed.
+	# Early return in case editor tree structure has changed.
+	if not editor_viewport_container:
+		return fallback_size
+	
 	if editor_viewport_container.get_class() != "Node3DEditorViewportContainer":
 		return fallback_size
 		
 	return editor_viewport_container.size
 
 func _on_resize_handle_button_down() -> void:
-	if state != InteractionState.NONE: return
+	if _state != InteractionState.NONE: return
 	
-	state = InteractionState.RESIZE
-	initial_mouse_position = get_global_mouse_position()
-	initial_panel_size = panel.size
+	_state = InteractionState.RESIZE
+	_initial_mouse_position = get_global_mouse_position()
+	_initial_panel_size = panel.size
 
 func _on_resize_handle_button_up() -> void:
-	state = InteractionState.NONE
+	_state = InteractionState.NONE
 
 func _on_drag_handle_button_down() -> void:
-	if state != InteractionState.NONE: return
+	if _state != InteractionState.NONE: return
 		
-	state = InteractionState.DRAG
-	initial_mouse_position = get_global_mouse_position()
-	initial_panel_position = panel.global_position
+	_state = InteractionState.DRAG
+	_initial_mouse_position = get_global_mouse_position()
+	_initial_panel_position = panel.global_position
 
 func _on_drag_handle_button_up() -> void:
-	if state != InteractionState.DRAG: return
+	if _state != InteractionState.DRAG: return
 	
-	state = InteractionState.START_ANIMATE_INTO_PLACE
+	_state = InteractionState.START_ANIMATE_INTO_PLACE
 
 func _on_lock_button_pressed() -> void:
-	is_locked = !is_locked
+	_is_locked = !_is_locked

--- a/addons/anthonyec.camera_preview/preview.gd.uid
+++ b/addons/anthonyec.camera_preview/preview.gd.uid
@@ -1,0 +1,1 @@
+uid://56ntugxskwub

--- a/addons/anthonyec.camera_preview/preview.tscn
+++ b/addons/anthonyec.camera_preview/preview.tscn
@@ -1,11 +1,11 @@
 [gd_scene load_steps=8 format=3 uid="uid://xybmfvufjuv"]
 
-[ext_resource type="Script" path="res://addons/anthonyec.camera_preview/preview.gd" id="1_6b32r"]
+[ext_resource type="Script" uid="uid://56ntugxskwub" path="res://addons/anthonyec.camera_preview/preview.gd" id="1_6b32r"]
 [ext_resource type="Texture2D" uid="uid://do6d60od41vmg" path="res://addons/anthonyec.camera_preview/Pin.svg" id="2_p0pa8"]
 [ext_resource type="Texture2D" uid="uid://btc01wc11tiid" path="res://addons/anthonyec.camera_preview/GuiResizerTopLeft.svg" id="2_t64ej"]
 [ext_resource type="Texture2D" uid="uid://04l05jxuyt7k" path="res://addons/anthonyec.camera_preview/GuiResizerTopRight.svg" id="3_6yuab"]
 
-[sub_resource type="ViewportTexture" id="ViewportTexture_hchdq"]
+[sub_resource type="ViewportTexture" id="ViewportTexture_m22c1"]
 viewport_path = NodePath("Panel/SubViewport")
 
 [sub_resource type="Gradient" id="Gradient_11p6r"]
@@ -55,7 +55,7 @@ anchor_top = 1.0
 anchor_right = 1.0
 anchor_bottom = 1.0
 offset_left = -520.0
-offset_top = -908.889
+offset_top = -301.0
 offset_right = -20.0
 offset_bottom = -20.0
 grow_horizontal = 0
@@ -94,7 +94,7 @@ theme_override_constants/margin_bottom = 4
 [node name="TextureRect" type="TextureRect" parent="Panel/ViewportMarginContainer"]
 unique_name_in_owner = true
 layout_mode = 2
-texture = SubResource("ViewportTexture_hchdq")
+texture = SubResource("ViewportTexture_m22c1")
 expand_mode = 1
 
 [node name="Gradient" type="TextureRect" parent="Panel"]
@@ -162,6 +162,7 @@ anchor_left = 1.0
 anchor_right = 1.0
 offset_left = -60.0
 offset_bottom = 60.0
+grow_horizontal = 0
 pivot_offset = Vector2(60, 60)
 size_flags_horizontal = 8
 size_flags_vertical = 0
@@ -180,6 +181,7 @@ anchor_top = 1.0
 anchor_bottom = 1.0
 offset_top = -60.0
 offset_right = 60.0
+grow_vertical = 0
 pivot_offset = Vector2(0, 60)
 size_flags_horizontal = 0
 size_flags_vertical = 8

--- a/addons/anthonyec.camera_preview/preview.tscn
+++ b/addons/anthonyec.camera_preview/preview.tscn
@@ -196,7 +196,5 @@ expand_icon = true
 [connection signal="button_up" from="Panel/OverlayMarginContainer/OverlayContainer/DragHandle" to="." method="_on_drag_handle_button_up"]
 [connection signal="renamed" from="Panel/OverlayMarginContainer/OverlayContainer/DragHandle" to="." method="_on_drag_handle_renamed"]
 [connection signal="button_down" from="Panel/OverlayMarginContainer/OverlayContainer/ResizeLeftHandle" to="." method="_on_resize_handle_button_down"]
-[connection signal="button_up" from="Panel/OverlayMarginContainer/OverlayContainer/ResizeLeftHandle" to="." method="_on_resize_handle_button_up"]
 [connection signal="button_down" from="Panel/OverlayMarginContainer/OverlayContainer/ResizeRightHandle" to="." method="_on_resize_handle_button_down"]
-[connection signal="button_up" from="Panel/OverlayMarginContainer/OverlayContainer/ResizeRightHandle" to="." method="_on_resize_handle_button_up"]
 [connection signal="pressed" from="Panel/OverlayMarginContainer/OverlayContainer/LockButton" to="." method="_on_lock_button_pressed"]

--- a/demo/.gitignore
+++ b/demo/.gitignore
@@ -1,2 +1,3 @@
 # Godot 4+ specific ignores
 .godot/
+.vscode/

--- a/demo/project.godot
+++ b/demo/project.godot
@@ -11,7 +11,11 @@ config_version=5
 [application]
 
 config/name="Little Camera Preview Demo"
-config/features=PackedStringArray("4.2", "GL Compatibility")
+config/features=PackedStringArray("4.5", "GL Compatibility")
+
+[debug]
+
+gdscript/warnings/untyped_declaration=2
 
 [editor_plugins]
 

--- a/demo/scripts/version.gd
+++ b/demo/scripts/version.gd
@@ -4,19 +4,19 @@ extends EditorScript
 const plugin_config_path = "res://addons/anthonyec.camera_preview/plugin.cfg"
 
 func _run() -> void:
-	var plugin_config = ConfigFile.new()
+	var plugin_config: ConfigFile = ConfigFile.new()
 	
-	var load_error = plugin_config.load(plugin_config_path)
+	var load_error: Error = plugin_config.load(plugin_config_path)
 	assert(load_error == OK, "Failed to load plugin config")
 	
-	var version = plugin_config.get_value("plugin", "version") as String
+	var version: String = plugin_config.get_value("plugin", "version") as String
 	assert(version, "Expected version number to exist")
 	
-	var parts = version.split(".")
+	var parts: PackedStringArray = version.split(".")
 	assert(parts.size() == 2, "Expected major and minor parts of version")
 	
-	var major = int(parts[0])
-	var minor = int(parts[1])
+	var major: int = int(parts[0])
+	var minor: int = int(parts[1])
 	
 	var new_version := "%s.%s" % [str(major), str(minor + 1)]
 	var tag_version := "v%s" % new_version
@@ -24,19 +24,19 @@ func _run() -> void:
 	plugin_config.set_value("plugin", "version", new_version)
 	plugin_config.save(plugin_config_path)
 	
-	var commit_path = "../" + plugin_config_path.trim_prefix("res://")
+	var commit_path: String = "../" + plugin_config_path.trim_prefix("res://")
 	
 	var output: Array
 	
 	# Used `git config --global gpg.program "$(which gpg)"` to ensure 
 	# commit signing works.
-	var commit_result = OS.execute("git", ["commit", "-m", tag_version, commit_path], output, true)
+	var commit_result: int = OS.execute("git", ["commit", "-m", tag_version, commit_path], output, true)
 	if commit_result != 0: return print("Error: ", output)
 	print("[✓] Created new commit")
 	
 	output.clear()
 	
-	var tag_result = OS.execute("git", ["tag", tag_version])
+	var tag_result: int = OS.execute("git", ["tag", tag_version])
 	if tag_result != 0: return print("Error: ", output)
 	print("[✓] Tagged commit")
 	

--- a/demo/scripts/version.gd.uid
+++ b/demo/scripts/version.gd.uid
@@ -1,0 +1,1 @@
+uid://54pmu6kcafat


### PR DESCRIPTION
Partially implements #13

Uses the built-in find_children() function (which seems optimized for this) to find a valid camera in children.

Searching siblings or parents seemed somewhat undefined, and would either need to rely on degrees of separation in the scenetree or proximity to the camera in 3D space in deciding what the "closest" camera is. This would also conflict a lot with keeping our desired camera on screen when pinned.

So, this seemed doable enough for now.