### PR TITLE
Fix resize stopping when mouse drag moves outside the preview

### DIFF
--- a/addons/anthonyec.camera_preview/preview.gd
+++ b/addons/anthonyec.camera_preview/preview.gd
@@ -233,6 +233,13 @@ func _process(_delta: float) -> void:
 		preview_camera_2d.limit_right = _selected_camera_2d.limit_right
 		preview_camera_2d.limit_top = _selected_camera_2d.limit_top
 		preview_camera_2d.limit_bottom = _selected_camera_2d.limit_bottom
+		
+func _input(event: InputEvent) -> void:
+	var mouse_button_event: InputEventMouseButton = event as InputEventMouseButton
+	if not mouse_button_event: return
+	
+	if mouse_button_event.is_released() and mouse_button_event.button_index == MOUSE_BUTTON_LEFT:
+		_on_mouse_button_up()
 
 func link_with_camera_3d(camera_3d: Camera3D) -> void:
 	# TODO: Camera may not be ready since this method is called in `_enter_tree` 
@@ -387,7 +394,9 @@ func _on_resize_handle_button_down() -> void:
 	_initial_mouse_position = get_global_mouse_position()
 	_initial_panel_size = panel.size
 
-func _on_resize_handle_button_up() -> void:
+func _on_mouse_button_up() -> void:
+	if _state != InteractionState.RESIZE: return
+	
 	_state = InteractionState.NONE
 
 func _on_drag_handle_button_down() -> void:

--- a/addons/anthonyec.camera_preview/preview.tscn
+++ b/addons/anthonyec.camera_preview/preview.tscn
@@ -196,7 +196,5 @@ expand_icon = true
 [connection signal="button_up" from="Panel/OverlayMarginContainer/OverlayContainer/DragHandle" to="." method="_on_drag_handle_button_up"]
 [connection signal="renamed" from="Panel/OverlayMarginContainer/OverlayContainer/DragHandle" to="." method="_on_drag_handle_renamed"]
 [connection signal="button_down" from="Panel/OverlayMarginContainer/OverlayContainer/ResizeLeftHandle" to="." method="_on_resize_handle_button_down"]
-[connection signal="button_up" from="Panel/OverlayMarginContainer/OverlayContainer/ResizeLeftHandle" to="." method="_on_resize_handle_button_up"]
 [connection signal="button_down" from="Panel/OverlayMarginContainer/OverlayContainer/ResizeRightHandle" to="." method="_on_resize_handle_button_down"]
-[connection signal="button_up" from="Panel/OverlayMarginContainer/OverlayContainer/ResizeRightHandle" to="." method="_on_resize_handle_button_up"]
 [connection signal="pressed" from="Panel/OverlayMarginContainer/OverlayContainer/LockButton" to="." method="_on_lock_button_pressed"]


### PR DESCRIPTION
Something changed internally in Godot with how buttons fire mouse release signals when the cursor leaves the button while pressed. I think this changed in Godot 4.5.

Also reported here: https://github.com/anthonyec/godot_little_camera_preview/issues/22